### PR TITLE
Implement hoare partition

### DIFF
--- a/psort.go
+++ b/psort.go
@@ -35,15 +35,27 @@ func Slice(slice interface{}, less compare, k int) {
 }
 
 func partition(rv *reflect.Value, swap swapFunc, less compare, start, end int) int {
-	i := start
-	for j := start + 1; j <= end; j++ {
-		if less(j, start) {
-			i++
-			swap(i, j)
+
+	left := start + 1
+	right := end
+
+	for left <= right {
+		for left <= end && less(left, start) {
+			left++
+		}
+		for right >= start && less(start, right) {
+			right--
+		}
+		if left <= right {
+			swap(left, right)
+			left++
+			right--
 		}
 	}
-	swap(i, start)
-	return i
+
+	swap(start, right)
+	return right
+
 }
 
 func quickSort(rv *reflect.Value, swap swapFunc, less compare, start, end int) {

--- a/psort_test.go
+++ b/psort_test.go
@@ -12,6 +12,7 @@ import (
 var (
 	size = 20000
 	k    = 100
+	d    = 16
 )
 
 func makeData(size int) []int {
@@ -46,6 +47,20 @@ func TestPSort(t *testing.T) {
 	}
 }
 
+func TestPSortDifferentSizes(t *testing.T) {
+	for size := 0; size < 100; size++ {
+		for kk := 0; kk <= size; kk++ {
+			data := makeData(size)
+			Slice(data, func(i, j int) bool {
+				return data[i] < data[j]
+			}, kk)
+			if !checkSorted(data, kk) {
+				t.Fatal(fmt.Sprintf("unsort error: %v", data[:k]))
+			}
+		}
+	}
+}
+
 func BenchmarkSort(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -66,6 +81,18 @@ func BenchmarkPSort(b *testing.B) {
 		b.StartTimer()
 		Slice(data, func(i, j int) bool {
 			return data[i] < data[j]
+		}, k)
+	}
+}
+
+func BenchmarkPSortLowDisc(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		data := makeData(size)
+		b.StartTimer()
+		Slice(data, func(i, j int) bool {
+			return data[i]%d < data[j]%d
 		}, k)
 	}
 }


### PR DESCRIPTION
Hello over there,

Thank you for this useful piece of code.

However, on my type of data I have found some kind of a problem which prevented the code to work as fast as it should be. In order to mitigate the problem, I implemented Hoare's partitioning and a new benchmark that tries to show the problem.

With my changes:

```
% go test -bench . -benchmem
goos: linux
goarch: amd64
pkg: github.com/Derlafff/psort
BenchmarkSort-4                      300           3524221 ns/op              64 B/op          2 allocs/op
BenchmarkPSort-4                    3000            412915 ns/op              64 B/op          2 allocs/op
BenchmarkPSortLowDisc-4             1000           1387552 ns/op              64 B/op          2 allocs/op
PASS
ok      github.com/Derlafff/psort       8.362s
```

Without my changes:

```
 % go test -bench . -benchmem                         
goos: linux
goarch: amd64
pkg: github.com/bluele/psort
BenchmarkSort-4                      500           3594622 ns/op              64 B/op          2 allocs/op
BenchmarkPSort-4                    3000            467009 ns/op              64 B/op          2 allocs/op
BenchmarkPSortLowDisc-4              300           5392569 ns/op              64 B/op          2 allocs/op
PASS
ok      github.com/bluele/psort 9.707s
```

I feel like there is a room for improvement both in the code and in the benchmark (it actually works much faster than on real data), but right now have no idea how to fix that.

Thank you.