### PR TITLE
Use random number for pivot

### DIFF
--- a/psort.go
+++ b/psort.go
@@ -1,6 +1,7 @@
 package psort
 
 import (
+	"math/rand"
 	"reflect"
 )
 
@@ -35,9 +36,9 @@ func Slice(slice interface{}, less compare, k int) {
 }
 
 func partition(rv *reflect.Value, swap swapFunc, less compare, start, end int) int {
-
 	left := start + 1
 	right := end
+	swap(start, rand.Intn(end-start)+start)
 
 	for left <= right {
 		for left <= end && less(left, start) {

--- a/psort_test.go
+++ b/psort_test.go
@@ -24,6 +24,14 @@ func makeData(size int) []int {
 	return vs
 }
 
+func makeReverseSorted(size int) []int {
+	vs := make([]int, size)
+	for i := 0; i < size; i++ {
+		vs[i] = size - i
+	}
+	return vs
+}
+
 func checkSorted(data []int, k int) bool {
 	var prev int
 	for i, v := range data[:k] {
@@ -93,6 +101,18 @@ func BenchmarkPSortLowDisc(b *testing.B) {
 		b.StartTimer()
 		Slice(data, func(i, j int) bool {
 			return data[i]%d < data[j]%d
+		}, k)
+	}
+}
+
+func BenchmarkPSortReverseSorted(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		data := makeReverseSorted(size)
+		b.StartTimer()
+		Slice(data, func(i, j int) bool {
+			return data[i] < data[j]
 		}, k)
 	}
 }


### PR DESCRIPTION
Before:
```
$ go test -bench . -benchmem -count=1                                                                                                                                                     git:master*
goos: darwin
goarch: amd64
pkg: github.com/bluele/psort
BenchmarkSort-4                              300           4020937 ns/op              64 B/op          2 allocs/op
BenchmarkPSort-4                            3000            408808 ns/op              64 B/op          2 allocs/op
BenchmarkPSortLowDisc-4                     1000           1448836 ns/op              64 B/op          2 allocs/op
BenchmarkPSortReverseSorted-4                100          18517292 ns/op              64 B/op          2 allocs/op
PASS
ok      github.com/bluele/psort 11.633s
```

After:
```
$ go test -bench . -benchmem -count=1                                                                                                                                        git:improve-performance*
goos: darwin
goarch: amd64
pkg: github.com/bluele/psort
BenchmarkSort-4                              500           3336768 ns/op              64 B/op          2 allocs/op
BenchmarkPSort-4                            5000            478204 ns/op              64 B/op          2 allocs/op
BenchmarkPSortLowDisc-4                     1000           1660928 ns/op              64 B/op          2 allocs/op
BenchmarkPSortReverseSorted-4               5000            244453 ns/op              64 B/op          2 allocs/op
PASS
ok      github.com/bluele/psort 14.597s
```